### PR TITLE
refactor(TSConfig) Revert noUnused* rules to default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,7 @@
     "lib": [
       "es2018",
       "dom"
-    ],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
+    ]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
## Purpose
Removed rules which generated annoying errors.
Reverts `noUnusedLocals` and `noUnusedParameters` rules to default (`false`).

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other...
```

## What to Check
Import unused element and you will not see annoying error.
